### PR TITLE
removing install_requires djangorestframework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setup(
     description='Swagger UI for Django REST Framework 2.3+',
     long_description=README,
     install_requires=[
-        'django>=1.5',
-        'djangorestframework>=2.3.5',
+        'django>=1.5'
     ],
 
     author='Marc Gibbons',


### PR DESCRIPTION
this resolves (or at least glosses over) a version mismatch between the fork of django rest framework we are using and the fork of django rest framework

the problem would manifest with django rest framework version 3, complete with its incompatible to version 2.4.x changes being installed by pip. This leads to unpredictable results when importing drf modules and 500 errors in the aviation app.
